### PR TITLE
Remove obsolete _config.php file

### DIFF
--- a/mysite/_config.php
+++ b/mysite/_config.php
@@ -1,9 +1,0 @@
-<?php
-use SilverStripe\Core\Environment;
-
-// find the database name from the environment file
-if (empty(Environment::getEnv('SS_DATABASE_NAME'))) {
-    Environment::setEnv('SS_DATABASE_NAME', 'SS_cwp');
-}
-
-date_default_timezone_set('Pacific/Auckland');


### PR DESCRIPTION
It was only filled with a fallback that no longer works in SilverStripe
Four, and a development type shim that should also be taken care of in
the runtime/deployment environment (be it development or production).

In response to testing SS4 against #1 