### PR TITLE
Allow developers to better use _ss_environment.php

### DIFF
--- a/mysite/_config.php
+++ b/mysite/_config.php
@@ -6,10 +6,10 @@ $project = 'mysite';
 global $database;
 
 // find the database name from the environment file
-if(defined('SS_DATABASE_NAME') && SS_DATABASE_NAME) {
+if (defined('SS_DATABASE_NAME') && SS_DATABASE_NAME) {
 	$database = SS_DATABASE_NAME;
-} else {
-	$database = 'SS_cwp';
+} elseif (!defined('SS_DATABASE_CHOOSE_NAME') || !SS_DATABASE_CHOOSE_NAME)) {
+    $database = 'SS_cwp';
 }
 
 require_once('conf/ConfigureFromEnv.php');


### PR DESCRIPTION
If a developer has several projects set up, it is likely they share environment settings between them. The configuration here however disallows the ease-of-use feature of _ss_environment.php to select a database name depending on the (grand)*parent folder's name.
So we should also check for this before dictating a fallback database name.

Resolves #1 