### PR TITLE
Remove lekoala/silverstripe-debugbar from dev requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",
-        "squizlabs/php_codesniffer": "^3",
-        "lekoala/silverstripe-debugbar": "^2@dev"
+        "squizlabs/php_codesniffer": "^3"
     },
     "extra": {
         "project-files": ["mysite/*"],


### PR DESCRIPTION
The module proxies the database connector, as do two other modules in the CWP
recipe. Since this is a dev tool and non-critical for production sites, we are
removing it from the recipe for now until a time where we have a better class
proxy system in place.