### PR TITLE
FIX don't try to test non existent files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit --testsuite $PHPUNIT_TEST; fi
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi
-  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs mysite/ *.php; fi
+  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs mysite/; fi
 
 after_success:
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi


### PR DESCRIPTION
Previously there was a _config.php file that we would run phpcs over in
the Travis CI tool. However this file was recently removed, so now the
build fails with:
ERROR: The file "*.php" does not exist.
So lets stop looking for/trying to sniff/clean it :)

c.f. https://travis-ci.org/creative-commoners/cwp-installer/jobs/340852193#L775