### PR TITLE
FIX Use correct Email namespace in cwpadmin email configuration

### DIFF
--- a/app/_config/cwpadmin.yml
+++ b/app/_config/cwpadmin.yml
@@ -3,5 +3,5 @@ Name: cwpadmin
 ---
 SilverStripe\Admin\LeftAndMain:
   help_link: "https://www.cwp.govt.nz/user-help/"
-SilverStripe\Control\Email:
+SilverStripe\Control\Email\Email:
   admin_email: 'no-reply@cwp.govt.nz'


### PR DESCRIPTION
Noticed while testing https://github.com/symbiote/silverstripe-queuedjobs/issues/25