### PR TITLE
Remove duplicate changelog config. Changelogs are generated from kitchen-sink in 2.x.

### DIFF
--- a/.cow.json
+++ b/.cow.json
@@ -1,7 +1,5 @@
 {
   "github-slug": "silverstripe/cwp-installer",
-  "changelog-holder": "cwp/cwp",
-  "changelog-path": "docs/en/05_Releases_and_changelogs/cwp_recipe_basic_{version}.md",
   "child-stability-inherit": [
     "cwp/cwp-recipe-core",
     "cwp/cwp-recipe-cms",


### PR DESCRIPTION
Having the config here as well means that cow overwrites the changelog with a cwp-installer changelog which does not include kitchen-sink (optional CWP) dependencies.