### PR TITLE
FIX Update Apache .htaccess for new access directives

### DIFF
--- a/app/.htaccess
+++ b/app/.htaccess
@@ -1,3 +1,3 @@
 <FilesMatch "\.(php|php3|php4|php5|phtml|inc)$">
-	Deny from all
+    Require all denied
 </FilesMatch>


### PR DESCRIPTION
Apache updated the way it handles permissions and access to files at version 2.4
SilverStripe has not updated its default .htaccess files to reflect this however
Most installations have been using mod_access_compat which has meant the (lack of)
update has gone largely unnoticed. However distributions are beginning to drop the
deprecation compatibility support module from their default setups, meaning that
after someone updates their infrastructure, the SilverStripe installation ceases
to be functional due to configuration syntax errors.

This commit seeks to rectify this (in part with another update in silverstripe/recipe-core)
by applying the advice given by Apache at
https://httpd.apache.org/docs/2.4/upgrading.html
and
https://httpd.apache.org/docs/2.4/howto/access.html

Ref: https://github.com/silverstripe/silverstripe-framework/issues/9001
Targetting master branch (as opposed to a lower branch with intention for a "merge-up") as CWP is on controlled infrastructure, as such this change is of no impact and the risk of lower versions ceasing operation is extremely low. Issues with merging to earlier branches can be seen in the comment thread at #27 