### PR TITLE
Use 2.x-dev instead of 2.5.x-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 
 env:
   global:
-    - COMPOSER_ROOT_VERSION=2.5.x-dev
+    - COMPOSER_ROOT_VERSION=2.x-dev
 
 matrix:
   include:

--- a/composer.json
+++ b/composer.json
@@ -6,19 +6,19 @@
     "require": {
         "php": ">=7.1.0",
         "silverstripe/recipe-plugin": "^1",
-        "cwp/cwp-recipe-core": "2.5.x-dev",
-        "cwp/cwp-recipe-cms": "2.5.x-dev",
-        "silverstripe/recipe-blog": "1.5.x-dev",
-        "silverstripe/recipe-form-building": "1.5.x-dev",
-        "silverstripe/recipe-authoring-tools": "1.5.x-dev",
-        "silverstripe/recipe-collaboration": "1.5.x-dev",
-        "silverstripe/recipe-reporting-tools": "1.5.x-dev",
-        "cwp/cwp-recipe-search": "2.5.x-dev",
-        "silverstripe/recipe-services": "1.5.x-dev",
-        "silverstripe/subsites": "2.3.x-dev",
-        "tractorcow/silverstripe-fluent": "4.4.x-dev",
-        "silverstripe/registry": "2.2.x-dev",
-        "cwp/starter-theme": "3.0.x-dev"
+        "cwp/cwp-recipe-core": "2.x-dev",
+        "cwp/cwp-recipe-cms": "2.x-dev",
+        "silverstripe/recipe-blog": "1.x-dev",
+        "silverstripe/recipe-form-building": "1.x-dev",
+        "silverstripe/recipe-authoring-tools": "1.x-dev",
+        "silverstripe/recipe-collaboration": "1.x-dev",
+        "silverstripe/recipe-reporting-tools": "1.x-dev",
+        "cwp/cwp-recipe-search": "2.x-dev",
+        "silverstripe/recipe-services": "1.x-dev",
+        "silverstripe/subsites": "2.x-dev",
+        "tractorcow/silverstripe-fluent": "4.x-dev",
+        "silverstripe/registry": "2.x-dev",
+        "cwp/starter-theme": "3.x-dev"
     },
     "suggest": {
         "silverstripe/recipe-content-blocks": "Supplement the CMS with a 'content block' approach to editing"


### PR DESCRIPTION
Don't merge without discussion first

Reversion of this commit
https://github.com/silverstripe/cwp-installer/commit/c344179afa21be354584c7e25c1bf4238d055d82#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780

Reasoning being that I want to run some pull-request through travis cwp-kitchen-sink to do pre-emptive testing of the next minor release, rather than testing against the current minor.

Also it's just weird have 2.x-dev of cwp/installer install 2.5.x-dev of all the recipes

However I'm vaguely remember something about us consciously choosing to get rid of 2.x-dev type of branches, though I don't know the history or reasoning behing this decision ... so there may be a good reason why not to merge this